### PR TITLE
Do not throw error on missing audience

### DIFF
--- a/Sample-01/api-server.js
+++ b/Sample-01/api-server.js
@@ -13,8 +13,13 @@ const baseUrl = process.env.AUTH0_BASE_URL;
 const issuerBaseUrl = process.env.AUTH0_ISSUER_BASE_URL;
 const audience = process.env.AUTH0_AUDIENCE;
 
-if (!baseUrl || !issuerBaseUrl || !audience) {
+if (!baseUrl || !issuerBaseUrl) {
   throw new Error('Please make sure that the file .env.local is in place and populated');
+}
+
+if (!audience) {
+  console.log('AUTH0_AUDIENCE not set in .env.local. Shutting down API server.');
+  process.exit(1);
 }
 
 app.use(morgan('dev'));


### PR DESCRIPTION
The login sample Readme [states](https://github.com/auth0-samples/auth0-nextjs-samples/tree/main/Sample-01#configuration) that the audience value is optional:

<img width="1028" alt="Screen Shot 2021-03-17 at 23 50 18" src="https://user-images.githubusercontent.com/5055789/111566248-95453500-877b-11eb-8f6f-7c129a632eb0.png">

However, if the audience is not set the following error is thrown when running the sample with `npm run dev`:

<img width="792" alt="Screen Shot 2021-03-17 at 23 40 26" src="https://user-images.githubusercontent.com/5055789/111566312-b148d680-877b-11eb-89ce-5608f3cecf1f.png">

While it doesn't prevent the rest of the sample from running, it makes for a rather poor experience. This PR logs a message when the audience is missing and then cleanly exits the API server instead:

<img width="783" alt="Screen Shot 2021-03-17 at 23 53 12" src="https://user-images.githubusercontent.com/5055789/111566471-f967f900-877b-11eb-9a0f-ae3cee2c7252.png">

