### PR TITLE
Use Next.js Image component

### DIFF
--- a/Sample-01/components/NavBar.jsx
+++ b/Sample-01/components/NavBar.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import Image from 'next/image';
 import {
   Collapse,
   Container,
@@ -70,13 +71,13 @@ const NavBar = () => {
               {user && (
                 <UncontrolledDropdown nav inNavbar data-testid="navbar-menu-desktop">
                   <DropdownToggle nav caret id="profileDropDown">
-                    <img
+                    <Image
                       src={user.picture}
                       alt="Profile"
                       className="nav-user-profile rounded-circle"
                       width="50"
                       height="50"
-                      decode="async"
+                      quality="100"
                       data-testid="navbar-picture-desktop"
                     />
                   </DropdownToggle>
@@ -117,13 +118,13 @@ const NavBar = () => {
                 data-testid="navbar-menu-mobile">
                 <NavItem>
                   <span className="user-info">
-                    <img
+                    <Image
                       src={user.picture}
                       alt="Profile"
                       className="nav-user-profile d-inline-block rounded-circle mr-3"
                       width="50"
                       height="50"
-                      decode="async"
+                      quality="100"
                       data-testid="navbar-picture-mobile"
                     />
                     <h6 className="d-inline-block" data-testid="navbar-user-mobile">

--- a/Sample-01/next.config.js
+++ b/Sample-01/next.config.js
@@ -1,3 +1,6 @@
 module.exports = {
+  images: {
+    domains: ['s.gravatar.com']
+  },
   poweredByHeader: false
 };

--- a/Sample-01/pages/profile.jsx
+++ b/Sample-01/pages/profile.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import Image from 'next/image';
 import { Row, Col } from 'reactstrap';
 import { useUser, withPageAuthRequired } from '@auth0/nextjs-auth0';
 
@@ -16,11 +17,13 @@ function Profile() {
         <>
           <Row className="align-items-center profile-header mb-5 text-center text-md-left" data-testid="profile">
             <Col md={2}>
-              <img
+              <Image
                 src={user.picture}
                 alt="Profile"
                 className="rounded-circle img-fluid profile-picture mb-3 mb-md-0"
-                decode="async"
+                width="120"
+                height="120"
+                quality="100"
                 data-testid="profile-picture"
               />
             </Col>

--- a/Sample-01/styles/globals.css
+++ b/Sample-01/styles/globals.css
@@ -21,6 +21,10 @@ p code {
   min-height: 170px;
 }
 
+.nav-item.dropdown .dropdown-toggle::after {
+  display: inline;
+}
+
 .nav-item.dropdown .dropdown-item {
   padding: 0;
 }


### PR DESCRIPTION
### Description

This PR replaces the use of `img` with Next.js `Image` [component](https://nextjs.org/docs/api-reference/next/image).

<img width="1031" alt="Screen Shot 2021-10-22 at 12 44 21" src="https://user-images.githubusercontent.com/5055789/138484713-59860e7a-6b89-44a8-aae7-4ff20a361997.png">

The changes have been tested manually in Chrome and Firefox.

### References

Fixes #17 