### PR TITLE
Update line references for outdated README links

### DIFF
--- a/Sample-01/README.md
+++ b/Sample-01/README.md
@@ -4,10 +4,10 @@ This sample demonstrates the integration of [Auth0 Next.js SDK](https://github.c
 
 This sample demonstrates the following use cases:
 
-- [Login](https://github.com/auth0-samples/auth0-nextjs-samples/blob/main/Sample-01/components/NavBar.jsx#L48-L54)
-- [Logout](https://github.com/auth0-samples/auth0-nextjs-samples/blob/main/Sample-01/components/NavBar.jsx#L80-L82)
+- [Login](https://github.com/auth0-samples/auth0-nextjs-samples/blob/main/Sample-01/components/NavBar.jsx#L61-L67)
+- [Logout](https://github.com/auth0-samples/auth0-nextjs-samples/blob/main/Sample-01/components/NavBar.jsx#L93-L95)
 - [Showing the user profile](https://github.com/auth0-samples/auth0-nextjs-samples/blob/main/Sample-01/pages/profile.jsx)
-- [Protecting client-side rendered pages](https://github.com/auth0-samples/auth0-nextjs-samples/blob/main/Sample-01/pages/profile.jsx#L42-L45)
+- [Protecting client-side rendered pages](https://github.com/auth0-samples/auth0-nextjs-samples/blob/main/Sample-01/pages/profile.jsx#L43-L46)
 - [Calling APIs](https://github.com/auth0-samples/auth0-nextjs-samples/blob/main/Sample-01/pages/external.jsx)
 
 ## Project setup


### PR DESCRIPTION
### Description

This PR updates a few links in the Sample-01 README to point at the correct line references.
Login:
<img width="488" alt="image" src="https://user-images.githubusercontent.com/20663545/196295551-80b63d03-413e-4fc6-8078-4516bb017c5c.png">

Logout:
<img width="818" alt="image" src="https://user-images.githubusercontent.com/20663545/196295586-0cc8eb43-cc87-4713-9687-2858e305e52d.png">

Protecting client-side rendered pages:
<img width="513" alt="image" src="https://user-images.githubusercontent.com/20663545/196295644-10b1c7d0-f3d2-4821-84e5-649f8d4b2e29.png">


### References

Fixes Issue: https://github.com/auth0-samples/auth0-nextjs-samples/issues/68