### PR TITLE
Migrate nextjs-auth0 to v4

### DIFF
--- a/Sample-01/.env.local.example
+++ b/Sample-01/.env.local.example
@@ -1,6 +1,6 @@
 AUTH0_SECRET=replace-with-your-own-secret-generated-with-openssl
-AUTH0_BASE_URL=http://localhost:3000
-AUTH0_ISSUER_BASE_URL='https://{DOMAIN}'
+APP_BASE_URL=http://localhost:3000
+AUTH0_DOMAIN='{DOMAIN}'
 AUTH0_CLIENT_ID='{CLIENT_ID}'
 AUTH0_CLIENT_SECRET='{CLIENT_SECRET}'
 AUTH0_AUDIENCE=

--- a/Sample-01/README.md
+++ b/Sample-01/README.md
@@ -36,9 +36,9 @@ To do this, first copy `.env.local.example` into a new file in the same folder c
 # A long secret value used to encrypt the session cookie
 AUTH0_SECRET='LONG_RANDOM_VALUE'
 # The base url of your application
-AUTH0_BASE_URL='http://localhost:3000'
-# The url of your Auth0 tenant domain
-AUTH0_ISSUER_BASE_URL='https://YOUR_AUTH0_DOMAIN.auth0.com'
+APP_BASE_URL='http://localhost:3000'
+# Your Auth0 tenant domain
+AUTH0_DOMAIN='YOUR_AUTH0_DOMAIN.auth0.com'
 # Your Auth0 application's Client ID
 AUTH0_CLIENT_ID='YOUR_AUTH0_CLIENT_ID'
 # Your Auth0 application's Client Secret

--- a/Sample-01/api-server.js
+++ b/Sample-01/api-server.js
@@ -9,11 +9,12 @@ const jwksRsa = require('jwks-rsa');
 
 const app = express();
 const port = process.env.API_PORT || 3001;
-const baseUrl = process.env.AUTH0_BASE_URL;
-const issuerBaseUrl = process.env.AUTH0_ISSUER_BASE_URL;
+const baseUrl = process.env.APP_BASE_URL;
+const domain = process.env.AUTH0_DOMAIN;
+const issuerBaseUrl = `https://${domain}`;
 const audience = process.env.AUTH0_AUDIENCE;
 
-if (!baseUrl || !issuerBaseUrl) {
+if (!baseUrl || !domain) {
   throw new Error('Please make sure that the file .env.local is in place and populated');
 }
 

--- a/Sample-01/app/api/auth/[auth0]/route.js
+++ b/Sample-01/app/api/auth/[auth0]/route.js
@@ -1,3 +1,0 @@
-import { handleAuth } from '@auth0/nextjs-auth0';
-
-export const GET = handleAuth();

--- a/Sample-01/app/api/shows/route.js
+++ b/Sample-01/app/api/shows/route.js
@@ -1,12 +1,19 @@
-import { getAccessToken, withApiAuthRequired } from '@auth0/nextjs-auth0';
 import { NextResponse } from 'next/server';
+import { auth0 } from '../../../lib/auth0';
 
-export const GET = withApiAuthRequired(async function shows(req) {
+export const GET = async function shows() {
   try {
+    const session = await auth0.getSession();
+
+    if (!session) {
+      return NextResponse.json(
+        { error: 'Not authenticated' },
+        { status: 401 }
+      );
+    }
+
     const res = new NextResponse();
-    const { accessToken } = await getAccessToken(req, res, {
-      scopes: ['read:shows']
-    });
+    const { token: accessToken } = await auth0.getAccessToken();
     const apiPort = process.env.API_PORT || 3001;
     const response = await fetch(`http://localhost:${apiPort}/api/shows`, {
       headers: {
@@ -19,4 +26,4 @@ export const GET = withApiAuthRequired(async function shows(req) {
   } catch (error) {
     return NextResponse.json({ error: error.message }, { status: error.status || 500 });
   }
-});
+};

--- a/Sample-01/app/csr/page.jsx
+++ b/Sample-01/app/csr/page.jsx
@@ -1,9 +1,8 @@
 'use client';
 
 import React from 'react';
-import { withPageAuthRequired } from '@auth0/nextjs-auth0/client';
 
-export default withPageAuthRequired(function CSRPage() {
+export default function CSRPage() {
   return (
     <>
       <div className="mb-5" data-testid="csr">
@@ -20,10 +19,10 @@ export default withPageAuthRequired(function CSRPage() {
             custom <a href="https://nextjs.org/docs/advanced-features/custom-app">App Component</a> with it.
           </p>
           <p>
-            You can also fetch the user profile by calling the <code>/api/auth/me</code> API route.
+            You can also fetch the user profile by calling the <code>/auth/profile</code> API route.
           </p>
         </div>
       </div>
     </>
   );
-});
+};

--- a/Sample-01/app/external/page.jsx
+++ b/Sample-01/app/external/page.jsx
@@ -2,13 +2,12 @@
 
 import React, { useState } from 'react';
 import { Button } from 'reactstrap';
-import { withPageAuthRequired } from '@auth0/nextjs-auth0/client';
 
 import Loading from '../../components/Loading';
 import ErrorMessage from '../../components/ErrorMessage';
 import Highlight from '../../components/Highlight';
 
-function External() {
+export default function External() {
   const [state, setState] = useState({ isLoading: false, response: undefined, error: undefined });
 
   const callApi = async () => {
@@ -68,8 +67,3 @@ function External() {
     </>
   );
 }
-
-export default withPageAuthRequired(External, {
-  onRedirecting: () => <Loading />,
-  onError: error => <ErrorMessage>{error.message}</ErrorMessage>
-});

--- a/Sample-01/app/layout.jsx
+++ b/Sample-01/app/layout.jsx
@@ -5,7 +5,7 @@ import NavBar from '../components/NavBar';
 import { Container } from 'reactstrap';
 import Footer from '../components/Footer';
 import React from 'react';
-import { UserProvider } from '@auth0/nextjs-auth0/client';
+import { Auth0Provider } from '@auth0/nextjs-auth0';
 
 export default function RootLayout({ children }) {
   return (
@@ -20,13 +20,13 @@ export default function RootLayout({ children }) {
         <link rel="stylesheet" href="https://cdn.auth0.com/js/auth0-samples-theme/1.0/css/auth0-theme.min.css" />
       </head>
       <body>
-        <UserProvider>
+        <Auth0Provider>
           <main id="app" className="d-flex flex-column h-100" data-testid="layout">
             <NavBar />
             <Container className="flex-grow-1 mt-5">{children}</Container>
             <Footer />
           </main>
-        </UserProvider>
+        </Auth0Provider>
       </body>
     </html>
   );

--- a/Sample-01/app/profile/page.jsx
+++ b/Sample-01/app/profile/page.jsx
@@ -2,13 +2,12 @@
 
 import React from 'react';
 import { Row, Col } from 'reactstrap';
-import { useUser, withPageAuthRequired } from '@auth0/nextjs-auth0/client';
+import { useUser } from '@auth0/nextjs-auth0';
 
 import Loading from '../../components/Loading';
-import ErrorMessage from '../../components/ErrorMessage';
 import Highlight from '../../components/Highlight';
 
-function Profile() {
+export default function Profile() {
   const { user, isLoading } = useUser();
 
   return (
@@ -41,8 +40,3 @@ function Profile() {
     </>
   );
 }
-
-export default withPageAuthRequired(Profile, {
-  onRedirecting: () => <Loading />,
-  onError: error => <ErrorMessage>{error.message}</ErrorMessage>
-});

--- a/Sample-01/app/ssr/page.jsx
+++ b/Sample-01/app/ssr/page.jsx
@@ -1,31 +1,28 @@
 import React from 'react';
-import { getSession, withPageAuthRequired } from '@auth0/nextjs-auth0';
+import { auth0 } from '../../lib/auth0';
 
 import Highlight from '../../components/Highlight';
 
-export default withPageAuthRequired(
-  async function SSRPage() {
-    const { user } = await getSession();
-    return (
-      <>
-        <div className="mb-5" data-testid="ssr">
-          <h1 data-testid="ssr-title">Server-side Rendered Page</h1>
-          <div data-testid="ssr-text">
-            <p>
-              You can protect a server-side rendered page by wrapping it with <code>withPageAuthRequired</code>. Only
-              logged in users will be able to access it. If the user is logged out, they will be redirected to the login
-              page instead.{' '}
-            </p>
-          </div>
+export default async function SSRPage() {
+  const { user } = await auth0.getSession();
+  return (
+    <>
+      <div className="mb-5" data-testid="ssr">
+        <h1 data-testid="ssr-title">Server-side Rendered Page</h1>
+        <div data-testid="ssr-text">
+          <p>
+            You can protect a server-side rendered page by wrapping it with <code>withPageAuthRequired</code>. Only
+            logged in users will be able to access it. If the user is logged out, they will be redirected to the login
+            page instead.{' '}
+          </p>
         </div>
-        <div className="result-block-container" data-testid="ssr-json">
-          <div className="result-block">
-            <h6 className="muted">User</h6>
-            <Highlight>{JSON.stringify(user, null, 2)}</Highlight>
-          </div>
+      </div>
+      <div className="result-block-container" data-testid="ssr-json">
+        <div className="result-block">
+          <h6 className="muted">User</h6>
+          <Highlight>{JSON.stringify(user, null, 2)}</Highlight>
         </div>
-      </>
-    );
-  },
-  { returnTo: '/ssr' }
-);
+      </div>
+    </>
+  );
+};

--- a/Sample-01/components/NavBar.jsx
+++ b/Sample-01/components/NavBar.jsx
@@ -14,7 +14,7 @@ import {
   DropdownMenu,
   DropdownItem
 } from 'reactstrap';
-import { useUser } from '@auth0/nextjs-auth0/client';
+import { useUser } from '@auth0/nextjs-auth0';
 
 import PageLink from './PageLink';
 import AnchorLink from './AnchorLink';
@@ -61,7 +61,7 @@ const NavBar = () => {
               {!isLoading && !user && (
                 <NavItem id="qsLoginBtn">
                   <AnchorLink
-                    href="/api/auth/login"
+                    href="/auth/login"
                     className="btn btn-primary btn-margin"
                     tabIndex={0}
                     testId="navbar-login-desktop">
@@ -92,7 +92,7 @@ const NavBar = () => {
                       </PageLink>
                     </DropdownItem>
                     <DropdownItem id="qsLogoutBtn">
-                      <AnchorLink href="/api/auth/logout" icon="power-off" testId="navbar-logout-desktop">
+                      <AnchorLink href="/auth/logout" icon="power-off" testId="navbar-logout-desktop">
                         Log out
                       </AnchorLink>
                     </DropdownItem>
@@ -103,7 +103,7 @@ const NavBar = () => {
             {!isLoading && !user && (
               <Nav className="d-md-none" navbar>
                 <AnchorLink
-                  href="/api/auth/login"
+                  href="/auth/login"
                   className="btn btn-primary btn-block"
                   tabIndex={0}
                   testId="navbar-login-mobile">
@@ -140,7 +140,7 @@ const NavBar = () => {
                 </NavItem>
                 <NavItem id="qsLogoutBtn">
                   <AnchorLink
-                    href="/api/auth/logout"
+                    href="/auth/logout"
                     className="btn btn-link p-0"
                     icon="power-off"
                     testId="navbar-logout-mobile">

--- a/Sample-01/lib/auth0.js
+++ b/Sample-01/lib/auth0.js
@@ -1,0 +1,18 @@
+import { Auth0Client } from "@auth0/nextjs-auth0/server";
+
+// Initialize the Auth0 client 
+export const auth0 = new Auth0Client({
+  // Options are loaded from environment variables by default
+  // Ensure necessary environment variables are properly set
+  // domain: process.env.AUTH0_DOMAIN,
+  // clientId: process.env.AUTH0_CLIENT_ID,
+  // clientSecret: process.env.AUTH0_CLIENT_SECRET,
+  // appBaseUrl: process.env.APP_BASE_URL,
+  // secret: process.env.AUTH0_SECRET,
+  authorizationParameters: {
+    // In v4, the AUTH0_SCOPE and AUTH0_AUDIENCE environment variables are no longer automatically picked up by the SDK.
+    // Instead, we need to provide the values explicitly.
+    scope: process.env.AUTH0_SCOPE,
+    audience: process.env.AUTH0_AUDIENCE,
+  }
+});

--- a/Sample-01/middleware.js
+++ b/Sample-01/middleware.js
@@ -1,0 +1,39 @@
+import { NextResponse } from "next/server";
+import { auth0 } from "./lib/auth0"
+
+export async function middleware(request) {
+    const authRes = await auth0.middleware(request);
+
+    // authentication routes — let the middleware handle it
+    if (request.nextUrl.pathname.startsWith("/auth")) {
+        return authRes;
+    }
+
+    // public routes — no need to check for session
+    if (request.nextUrl.pathname === ("/")) {
+        return authRes;
+    }
+
+    const { origin } = new URL(request.url)
+    const session = await auth0.getSession()
+
+    // user does not have a session — redirect to login
+    if (!session) {
+        return NextResponse.redirect(`${origin}/auth/login`)
+    }
+
+    return authRes
+}
+
+export const config = {
+    matcher: [
+        /*
+         * Match all request paths except for the ones starting with:
+         * - _next/static (static files)
+         * - _next/image (image optimization files)
+         * - favicon.ico, sitemap.xml, robots.txt (metadata files)
+         * - api (API routes)
+         */
+        "/((?!_next/static|_next/image|favicon.ico|sitemap.xml|robots.txt|api).*)",
+    ],
+}

--- a/Sample-01/package-lock.json
+++ b/Sample-01/package-lock.json
@@ -8,7 +8,7 @@
       "name": "auth0-nextjs-sample",
       "version": "0.1.0",
       "dependencies": {
-        "@auth0/nextjs-auth0": "^3.5.0",
+        "@auth0/nextjs-auth0": "^4.2.1",
         "@fortawesome/fontawesome-svg-core": "^6.7.2",
         "@fortawesome/free-solid-svg-icons": "^6.7.2",
         "@fortawesome/react-fontawesome": "^0.2.2",
@@ -65,33 +65,30 @@
       }
     },
     "node_modules/@auth0/nextjs-auth0": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@auth0/nextjs-auth0/-/nextjs-auth0-3.5.0.tgz",
-      "integrity": "sha512-uFZEE2QQf1zU+jRK2fwqxRQt+WSqDPYF2tnr7d6BEa7b6L6tpPJ3evzoImbWSY1a7gFdvD7RD/Rvrsx7B5CKVg==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@auth0/nextjs-auth0/-/nextjs-auth0-4.2.1.tgz",
+      "integrity": "sha512-CZM9uOtznz3bUYPU5vIARFTomVk2pzGeR4lI0RxumdFkevoaA9NEPHRw2XzwOx5t97SdiR6kkQ8hw8IM+mkObg==",
+      "license": "MIT",
       "dependencies": {
-        "@panva/hkdf": "^1.0.2",
-        "cookie": "^0.6.0",
-        "debug": "^4.3.4",
-        "joi": "^17.6.0",
-        "jose": "^4.9.2",
-        "oauth4webapi": "^2.3.0",
-        "openid-client": "^5.2.1",
-        "tslib": "^2.4.0",
-        "url-join": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=16"
+        "@edge-runtime/cookies": "^5.0.1",
+        "@panva/hkdf": "^1.2.1",
+        "jose": "^5.9.6",
+        "oauth4webapi": "^3.1.2",
+        "swr": "^2.2.5"
       },
       "peerDependencies": {
-        "next": ">=10"
+        "next": "^14.2.25 || ^15.2.3",
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-0",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-0"
       }
     },
-    "node_modules/@auth0/nextjs-auth0/node_modules/cookie": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
-      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
-      "engines": {
-        "node": ">= 0.6"
+    "node_modules/@auth0/nextjs-auth0/node_modules/jose": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
+      "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -622,6 +619,15 @@
       "dev": true,
       "dependencies": {
         "ms": "^2.1.1"
+      }
+    },
+    "node_modules/@edge-runtime/cookies": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@edge-runtime/cookies/-/cookies-5.0.2.tgz",
+      "integrity": "sha512-Sd8LcWpZk/SWEeKGE8LT6gMm5MGfX/wm+GPnh1eBEtCpya3vYqn37wYknwAHw92ONoyyREl1hJwxV/Qx2DWNOg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/@emnapi/core": {
@@ -1312,12 +1318,14 @@
     "node_modules/@hapi/hoek": {
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
-      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ=="
+      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==",
+      "dev": true
     },
     "node_modules/@hapi/topo": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
       "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
+      "dev": true,
       "dependencies": {
         "@hapi/hoek": "^9.0.0"
       }
@@ -2752,9 +2760,10 @@
       }
     },
     "node_modules/@panva/hkdf": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@panva/hkdf/-/hkdf-1.1.1.tgz",
-      "integrity": "sha512-dhPeilub1NuIG0X5Kvhh9lH4iW3ZsHlnzwgwbOlgwQ2wG1IqFzsgHqmKPk3WzsdWAeaxKJxgM0+W433RmN45GA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@panva/hkdf/-/hkdf-1.2.1.tgz",
+      "integrity": "sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw==",
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
@@ -3066,6 +3075,7 @@
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.4.tgz",
       "integrity": "sha512-7vwq+rOHVWjyXxVlR76Agnvhy8I9rpzjosTESvmhNeXOXdZZB15Fl+TI9x1SiHZH5Jv2wTGduSxFDIaq0m3DUw==",
+      "dev": true,
       "dependencies": {
         "@hapi/hoek": "^9.0.0"
       }
@@ -3073,12 +3083,14 @@
     "node_modules/@sideway/formula": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.1.tgz",
-      "integrity": "sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg=="
+      "integrity": "sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg==",
+      "dev": true
     },
     "node_modules/@sideway/pinpoint": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
-      "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ=="
+      "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==",
+      "dev": true
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
@@ -6244,7 +6256,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -11064,6 +11075,7 @@
       "version": "17.9.2",
       "resolved": "https://registry.npmjs.org/joi/-/joi-17.9.2.tgz",
       "integrity": "sha512-Itk/r+V4Dx0V3c7RLFdRh12IOjySm2/WGPMubBT92cQvRfYZhPM2W0hZlctjj72iES8jsRCwp7S/cRmWBnJ4nw==",
+      "dev": true,
       "dependencies": {
         "@hapi/hoek": "^9.0.0",
         "@hapi/topo": "^5.0.0",
@@ -12178,9 +12190,10 @@
       "dev": true
     },
     "node_modules/oauth4webapi": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-2.3.0.tgz",
-      "integrity": "sha512-JGkb5doGrwzVDuHwgrR4nHJayzN4h59VCed6EW8Tql6iHDfZIabCJvg6wtbn5q6pyB2hZruI3b77Nudvq7NmvA==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-3.3.1.tgz",
+      "integrity": "sha512-ZwX7UqYrP3Lr+Glhca3a1/nF2jqf7VVyJfhGuW5JtrfDUxt0u+IoBPzFjZ2dd7PJGkdM6CFPVVYzuDYKHv101A==",
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
@@ -12191,14 +12204,6 @@
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/object-hash": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.2.0.tgz",
-      "integrity": "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==",
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/object-inspect": {
@@ -12313,14 +12318,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/oidc-token-hash": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/oidc-token-hash/-/oidc-token-hash-5.0.3.tgz",
-      "integrity": "sha512-IF4PcGgzAr6XXSff26Sk/+P4KZFJVuHAJZj3wgO3vX2bMdNVp/QXTP3P7CEm9V1IdG8lDLY3HhiqpsE/nOwpPw==",
-      "engines": {
-        "node": "^10.13.0 || >=12.0.0"
-      }
-    },
     "node_modules/on-finished": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -12363,36 +12360,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/openid-client": {
-      "version": "5.4.3",
-      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-5.4.3.tgz",
-      "integrity": "sha512-sVQOvjsT/sbSfYsQI/9liWQGVZH/Pp3rrtlGEwgk/bbHfrUDZ24DN57lAagIwFtuEu+FM9Ev7r85s8S/yPjimQ==",
-      "dependencies": {
-        "jose": "^4.14.4",
-        "lru-cache": "^6.0.0",
-        "object-hash": "^2.2.0",
-        "oidc-token-hash": "^5.0.3"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/panva"
-      }
-    },
-    "node_modules/openid-client/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/openid-client/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/optionator": {
       "version": "0.9.4",
@@ -14284,6 +14251,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/swr": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.3.3.tgz",
+      "integrity": "sha512-dshNvs3ExOqtZ6kJBaAsabhPdHyeY4P2cKwRCniDVifBMoG/SVI7tfLWqPXriVspf2Rg4tPzXJTnwaihIeFw2A==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -14830,11 +14810,6 @@
         "punycode": "^2.1.0"
       }
     },
-    "node_modules/url-join": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
-      "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA=="
-    },
     "node_modules/url-parse": {
       "version": "1.5.10",
       "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
@@ -14843,6 +14818,15 @@
       "dependencies": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.4.0.tgz",
+      "integrity": "sha512-9WXSPC5fMv61vaupRkCKCxsPxBocVnwakBEkMIHHpkTTg6icbJtg6jzgtLDm4bl3cSHAca52rYWih0k4K3PfHw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/utils-merge": {

--- a/Sample-01/package.json
+++ b/Sample-01/package.json
@@ -16,7 +16,7 @@
     "cypress:open": "cypress open --browser chrome"
   },
   "dependencies": {
-    "@auth0/nextjs-auth0": "^3.5.0",
+    "@auth0/nextjs-auth0": "^4.2.1",
     "@fortawesome/fontawesome-svg-core": "^6.7.2",
     "@fortawesome/free-solid-svg-icons": "^6.7.2",
     "@fortawesome/react-fontawesome": "^0.2.2",

--- a/Sample-01/tests/app/csr.test.jsx
+++ b/Sample-01/tests/app/csr.test.jsx
@@ -1,15 +1,15 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import { UserProvider } from '@auth0/nextjs-auth0/client';
+import { Auth0Provider } from '@auth0/nextjs-auth0';
 
 import CSRPage from '../../app/csr/page';
 
 describe('csr', () => {
   it('should render without crashing', async () => {
     render(
-      <UserProvider user={{}}>
+      <Auth0Provider user={{}}>
         <CSRPage />
-      </UserProvider>
+      </Auth0Provider>
     );
 
     expect(screen.getByTestId('csr')).toBeInTheDocument();

--- a/Sample-01/tests/app/external.test.jsx
+++ b/Sample-01/tests/app/external.test.jsx
@@ -2,12 +2,12 @@ import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 
 import _External from '../../app/external/page';
-import { UserProvider } from '@auth0/nextjs-auth0/client';
+import { Auth0Provider } from '@auth0/nextjs-auth0';
 
 const External = () => (
-  <UserProvider user={{}}>
+  <Auth0Provider user={{}}>
     <_External />
-  </UserProvider>
+  </Auth0Provider>
 );
 
 describe('index', () => {

--- a/Sample-01/tests/app/profile.test.jsx
+++ b/Sample-01/tests/app/profile.test.jsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 
-import { withUserProvider, mockUser } from '../fixtures';
+import { withAuth0Provider, mockUser } from '../fixtures';
 import Profile from '../../app/profile/page';
 
 describe('profile', () => {
   it('should render without crashing', async () => {
-    render(<Profile />, { wrapper: withUserProvider({ user: mockUser }) });
+    render(<Profile />, { wrapper: withAuth0Provider({ user: mockUser }) });
 
     expect(screen.queryByTestId('loading')).not.toBeInTheDocument();
     expect(screen.getByTestId('profile')).toBeInTheDocument();
@@ -16,14 +16,14 @@ describe('profile', () => {
   });
 
   it('should render a spinner when the user is loading', async () => {
-    render(<Profile />, { wrapper: withUserProvider({ user: undefined }) });
+    render(<Profile />, { wrapper: withAuth0Provider({ user: undefined }) });
 
     waitFor(() => screen.getByTestId('loading').toBeInTheDocument());
     waitFor(() => screen.queryByTestId('profile').not.toBeInTheDocument());
   });
 
   it('should render the user profile', async () => {
-    render(<Profile />, { wrapper: withUserProvider({ user: mockUser }) });
+    render(<Profile />, { wrapper: withAuth0Provider({ user: mockUser }) });
 
     waitFor(() => screen.queryByTestId('loading').not.toBeInTheDocument());
     Object.keys(mockUser).forEach(key => {

--- a/Sample-01/tests/components/Layout.test.jsx
+++ b/Sample-01/tests/components/Layout.test.jsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 
-import { withUserProvider } from '../fixtures';
+import { withAuth0Provider } from '../fixtures';
 import Layout from '../../components/Layout';
 
 describe('Layout', () => {
   it('should render without crashing', async () => {
-    render(<Layout>Text</Layout>, { wrapper: withUserProvider({ user: undefined }) });
+    render(<Layout>Text</Layout>, { wrapper: withAuth0Provider({ user: undefined }) });
 
     await waitFor(() => expect(screen.getByTestId('layout')).toBeInTheDocument());
     expect(screen.getByTestId('navbar')).toBeInTheDocument();

--- a/Sample-01/tests/components/NavBar.test.jsx
+++ b/Sample-01/tests/components/NavBar.test.jsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 
-import { withUserProvider, mockUser } from '../fixtures';
+import { withAuth0Provider, mockUser } from '../fixtures';
 import NavBar from '../../components/NavBar';
 
 describe('NavBar', () => {
   it('should render in logged out state', async () => {
-    render(<NavBar />, { wrapper: withUserProvider({ user: undefined }) });
+    render(<NavBar />, { wrapper: withAuth0Provider({ user: undefined }) });
 
     expect(screen.getByTestId('navbar')).toBeInTheDocument();
     expect(screen.getByTestId('navbar-toggle')).toBeInTheDocument();
@@ -20,7 +20,7 @@ describe('NavBar', () => {
   });
 
   it('should render in logged in state', async () => {
-    render(<NavBar />, { wrapper: withUserProvider({ user: mockUser }) });
+    render(<NavBar />, { wrapper: withAuth0Provider({ user: mockUser }) });
 
     expect(screen.getByTestId('navbar-items').children).toHaveLength(4);
     expect(screen.getByTestId('navbar-home')).toBeInTheDocument();

--- a/Sample-01/tests/fixtures.jsx
+++ b/Sample-01/tests/fixtures.jsx
@@ -1,4 +1,4 @@
-import { UserProvider } from '@auth0/nextjs-auth0/client';
+import { Auth0Provider } from '@auth0/nextjs-auth0';
 
 export const mockUser = {
   email: 'foo@example.com',
@@ -10,6 +10,6 @@ export const mockUser = {
   updated_at: null
 };
 
-export const withUserProvider = ({ user, profileUrl } = {}) => {
-  return props => <UserProvider {...props} user={user} profileUrl={profileUrl} />;
+export const withAuth0Provider = ({ user, profileUrl } = {}) => {
+  return props => <Auth0Provider {...props} user={user} profileUrl={profileUrl} />;
 };

--- a/Sample-01/tests/setup.js
+++ b/Sample-01/tests/setup.js
@@ -14,15 +14,15 @@ vi.mock('next/navigation', () => ({
   usePathname: () => ''
 }));
 
-vi.mock('@auth0/nextjs-auth0', () => {
+vi.mock('./../lib/auth0', () => {
   return {
-    getSession: () => ({
-      user: {
-        sub: 'bob'
-      }
-    }),
-    getAccessToken: () => 'access_token',
-    withApiAuthRequired: handler => handler,
-    withPageAuthRequired: page => () => page()
+    auth0: {
+      getSession: () => ({
+        user: {
+          sub: 'bob'
+        }
+      }),
+      getAccessToken: () => 'access_token',
+    }
   };
 });


### PR DESCRIPTION
This PR updates the sample application to use v4 of the `@auth0/nextjs-auth0` SDK. 

The most significant change is that the authentication is handled by the middleware now, and we no longer have things such as `withApiAuthRequired` and `withPageAuthRequired`.

Additionally, we introduce a `lib/auth0` file, which we use to call things such as `getSession()` and `getAccessToken()`.

Let's first merge https://github.com/auth0-samples/auth0-nextjs-samples/pull/181, then I will rebase this branch to simplify the diff.