### PR TITLE
Use structured entries for env snippet

### DIFF
--- a/quickstart/quickstart-login.yaml
+++ b/quickstart/quickstart-login.yaml
@@ -62,19 +62,33 @@ snippets:
     source: "quickstart/scripts/install-auth0.sh"
     language: "bash"
   env: &env
+    type: constructed
     fileName: *defaultEnvFileName
-    content: | # make
-      APP_BASE_URL=%APP_SCHEME%://%APP_DOMAIN%:%PORT%
-      AUTH0_DOMAIN=%AUTH0_DOMAIN%
-      AUTH0_CLIENT_ID=%AUTH0_CLIENT_ID%
-      AUTH0_CLIENT_SECRET=%AUTH0_CLIENT_SECRET%
-
-      # 64 character random string to encrypt the session cookie
-      #
-      # We're generating a secret for your convenience, but for production,
-      # generate your own secret using `openssl rand -hex 32`
-      AUTH0_SECRET=%AUTH0_SECRET%
     language: "bash"
+    entries:
+      - type: var
+        name: APP_BASE_URL
+        value: "%APP_SCHEME%://%APP_DOMAIN%:%PORT%"
+      - type: var
+        name: AUTH0_DOMAIN
+        value: "%AUTH0_DOMAIN%"
+      - type: var
+        name: AUTH0_CLIENT_ID
+        value: "%AUTH0_CLIENT_ID%"
+      - type: var
+        name: AUTH0_CLIENT_SECRET
+        value: "%AUTH0_CLIENT_SECRET%"
+        sensitive: true
+      - type: separator
+      - type: var
+        name: AUTH0_SECRET
+        value: "%AUTH0_SECRET%"
+        sensitive: true
+        comment: |
+          64 character random string to encrypt the session cookie
+
+          We're generating a secret for your convenience, but for production,
+          generate your own secret using `openssl rand -hex 32`
   lib-auth0: &libAuth0
     source: "lib/auth0.js"
     language: "js"


### PR DESCRIPTION
## Summary
- Replace raw `content` string in the env snippet with structured `entries`
  array in `quickstart-login.yaml`
- Add per-variable metadata (`sensitive`, `comment`, `separator`) to support
  richer env file generation

## Test plan
- [ ] `tools/ensure-env.cjs` still resolves `envSnippet.fileName` correctly
- [ ] `tools/check-port-and-start.cjs` still resolves `envSnippet.fileName`
  and starts the dev server on the configured port