### PR TITLE
fix: update Auth0 logo to current brand via CSS override

### DIFF
--- a/Sample-01/app/globals.css
+++ b/Sample-01/app/globals.css
@@ -37,3 +37,11 @@ p code {
 .result-block-container .result-block {
   opacity: 1;
 }
+
+.nav-container .logo {
+  background-image: url("https://cdn.auth0.com/quantum-assets/dist/latest/logos/auth0/auth0-lockup-en-onlight.svg");
+  background-repeat: no-repeat;
+  background-size: contain;
+  width: 110px;
+  height: 32px;
+}


### PR DESCRIPTION
 Summary

  - The auth0-samples-theme/1.0 CDN stylesheet embeds an outdated Auth0 logo as a base64 SVG in the .logo CSS rule
  - No newer version of this CDN theme exists (1.1+ returns 403)
  - Adds a .nav-container .logo override in globals.css to replace the old logo with the current Auth0 lockup from the quantum-assets CDN
  
  The fix uses a CSS specificity override (.nav-container .logo) rather than replacing the CDN theme entirely, keeping the change minimal and non-breaking.